### PR TITLE
Add descriptions to subparsers, defaulting to the (short) help if not defined

### DIFF
--- a/nicfit/command.py
+++ b/nicfit/command.py
@@ -31,12 +31,18 @@ class Command(object):
         return Class.HELP if hasattr(Class, "HELP") else None
 
     @classmethod
+    def desc(Class):
+        return Class.DESC if hasattr(Class, "DESC") else Class.help()
+
+    @classmethod
     def aliases(Class):
         return Class.ALIASES if hasattr(Class, "ALIASES") else []
 
     def __init__(self, subparsers):
         self.subparsers = subparsers
-        self.parser = self.subparsers.add_parser(self.name(), help=self.help(),
+        self.parser = self.subparsers.add_parser(self.name(),
+                                                 help=self.help(),
+                                                 description=self.desc(),
                                                  aliases=self.aliases())
         self._initArgParser(self.parser)
         self.parser.set_defaults(command_func=self.run)


### PR DESCRIPTION
Example, adduser has a DESC and listusers does not. Without this change, listusers would have no help verbage when running its --help.

Commands:
  Database command line options (or config) are required by most sub
  commands.

  {help,adduser,deluser,listusers,password,serve,info,sync,split-artists,merge-artists}
    help                Show help for a sub command
    adduser             Add a user to the database.
    deluser             Delete a user from the database.
    listusers           List users in the database
    password            Change a users password.
    serve               Run the unsonic web interface using the Pyramid pserve
                        script.
    info                Show information about the database and configuration.
    sync                Syncronize music directories with database.
    split-artists       Split a single artist name into N distinct artists.
    merge-artists       Merge two or more artists into a single artist.
baron@localhost ~/src/unsonic $ ./bin/unsonic adduser --help
usage: mishmash adduser [-h] username password ...

Adds a user to the database with the prefered roles.

positional arguments:
  username    Username
  password    Password
  roles       Roles for the user

optional arguments:
  -h, --help  show this help message and exit
baron@localhost ~/src/unsonic $ 
baron@localhost ~/src/unsonic $ ./bin/unsonic listusers --help
usage: mishmash listusers [-h]

List users in the database

optional arguments:
  -h, --help  show this help message and exit
